### PR TITLE
add access_token to entries_exists

### DIFF
--- a/wallabag_api/wallabag.py
+++ b/wallabag_api/wallabag.py
@@ -332,7 +332,8 @@ class Wallabag(object):
 
         :return result
         """
-        params = {'url': url,
+        params = {'access_token': self.token,
+                  'url': url,
                   'urls': urls}
 
         path = '/api/entries/exists.{ext}'.format(ext=self.format)


### PR DESCRIPTION
Hi,

I think there is a `access_token` missing, as I get an error otherwise:
`aiohttp.http_exceptions.HttpProcessingError: 401, message='{'error': 'access_denied', 'error_description': 'OAuth2 authentication required'}'`